### PR TITLE
Feat/storefilter

### DIFF
--- a/src/main/java/com/example/team5project/domain/storefilter/controller/StoreController.java
+++ b/src/main/java/com/example/team5project/domain/storefilter/controller/StoreController.java
@@ -1,0 +1,29 @@
+package com.example.team5project.domain.storefilter.controller;
+
+import com.example.team5project.domain.storefilter.entity.Store;
+import com.example.team5project.domain.storefilter.service.StoreService;
+import com.example.team5project.domain.storefilter.status.StoreStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/stores")
+@RequiredArgsConstructor
+public class StoreController {
+
+    private final StoreService storeService;
+
+    @GetMapping
+    public ResponseEntity<List<Store>> getStores(
+            @RequestParam(required = false) Double rating,
+            @RequestParam(required = false) StoreStatus status) {
+        List<Store> stores = storeService.getFilteredStores(rating, status);
+        return ResponseEntity.ok(stores);
+    }
+}

--- a/src/main/java/com/example/team5project/domain/storefilter/entity/Store.java
+++ b/src/main/java/com/example/team5project/domain/storefilter/entity/Store.java
@@ -1,0 +1,24 @@
+package com.example.team5project.domain.storefilter.entity;
+
+import com.example.team5project.domain.storefilter.status.StoreStatus;
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+
+@Entity
+public class Store {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private Double rating; //전체평가 점수
+
+
+    @Enumerated(EnumType.STRING)
+    private StoreStatus status; //업소상태
+
+    private LocalDate monitoringDate; // 모니터링 날짜
+}

--- a/src/main/java/com/example/team5project/domain/storefilter/repository/StoreRepository.java
+++ b/src/main/java/com/example/team5project/domain/storefilter/repository/StoreRepository.java
@@ -1,0 +1,10 @@
+package com.example.team5project.domain.storefilter.repository;
+
+import com.example.team5project.domain.storefilter.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StoreRepository extends JpaRepository<Store, Long>, JpaSpecificationExecutor<Store> {
+}

--- a/src/main/java/com/example/team5project/domain/storefilter/service/StoreService.java
+++ b/src/main/java/com/example/team5project/domain/storefilter/service/StoreService.java
@@ -1,0 +1,34 @@
+package com.example.team5project.domain.storefilter.service;
+
+import com.example.team5project.domain.storefilter.entity.Store;
+import com.example.team5project.domain.storefilter.repository.StoreRepository;
+import com.example.team5project.domain.storefilter.specification.StoreSpecification;
+import com.example.team5project.domain.storefilter.status.StoreStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StoreService {
+
+    private final StoreRepository storeRepository;
+
+    @Transactional
+    public List<Store> getFilteredStores(Double rating, StoreStatus status) {
+        Specification<Store> spec = Specification.where(StoreSpecification.orderByMonitoringDateDesc());
+
+        if (rating != null) {
+            spec = spec.and(StoreSpecification.filterByRating(rating));
+        }
+        if (status != null) {
+            spec = spec.and(StoreSpecification.filterByStatus(status));
+        }
+
+        return storeRepository.findAll(spec, PageRequest.of(0, 10)).getContent();
+    }
+}

--- a/src/main/java/com/example/team5project/domain/storefilter/specification/StoreSpecification.java
+++ b/src/main/java/com/example/team5project/domain/storefilter/specification/StoreSpecification.java
@@ -1,0 +1,26 @@
+package com.example.team5project.domain.storefilter.specification;
+
+import com.example.team5project.domain.storefilter.entity.Store;
+import com.example.team5project.domain.storefilter.status.StoreStatus;
+import org.springframework.data.jpa.domain.Specification;
+
+public class StoreSpecification {
+
+    public static Specification<Store> filterByRating(Double rating) {
+        return ((root, query, criteriaBuilder) ->
+                rating != null ? criteriaBuilder.equal(root.get("rating"), rating) : null);
+    }
+
+    public static Specification<Store> filterByStatus(StoreStatus status) {
+        return ((root, query, criteriaBuilder) ->
+                status != null ? criteriaBuilder.equal(root.get("status"), status) : null);
+    }
+
+    public static Specification<Store> orderByMonitoringDateDesc() {
+        return (root, query, criteriaBuilder) -> {
+          query.orderBy(criteriaBuilder.desc(root.get("monitoringDate")));
+          return null;
+        };
+    }
+}
+

--- a/src/main/java/com/example/team5project/domain/storefilter/status/StoreStatus.java
+++ b/src/main/java/com/example/team5project/domain/storefilter/status/StoreStatus.java
@@ -1,0 +1,5 @@
+package com.example.team5project.domain.storefilter.status;
+
+public enum StoreStatus {
+    사이트운영중단, 휴업중, 광고용_홍보용, 동록정보불일치, 사이트페쇄, 영업중, 확인안됨
+}


### PR DESCRIPTION
- [ ]  **업체 리스트 조회 중 필터 기능**
    - ‘전체평가’ 필터 조회와 ‘업소상태’ 필터 조회(2개 필터 동시 적용, 각각 1개씩 적용) 상위 10개 리스트 보여주기를 만들어요. 조회 조건은 다음을 참고해 주세요.
        - ‘전체평가’ 필터 조회
            - ‘전체평가’는 0점 ~ 3점 으로 이루어져 있고 점수를 입력하여 해당 업체 리스트만 조회
            - 예) ‘전체평가’가 3점인 경우만 리스트 조회
        - ‘업소상태’ 필터 조회
            - `사이트운영중단`, `휴업중`, `광고용(홍보용)`, `등록정보불일치`, `사이트폐쇄`, `영업중`, `확인안됨` 상태 중 1개를 선택하여 해당 업체 리스트만 조회
        - ‘모니터링날짜’의 내림차순 
 기능들 모두 넣었습니다 문제점 있으면 말해주세요